### PR TITLE
Remove swagger from routes

### DIFF
--- a/src/Hl7.DemoFileSystemFhirServer.AspNetCore/Hl7.DemoFileSystemFhirServer.AspNetCore.csproj
+++ b/src/Hl7.DemoFileSystemFhirServer.AspNetCore/Hl7.DemoFileSystemFhirServer.AspNetCore.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$TargetFramework)' != 'netcoreapp2.2'">
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Hl7.Fhir.DemoFileSystemServer\Hl7.Fhir.R4.DemoFileSystemServer.csproj" />
     <ProjectReference Include="..\Hl7.Fhir.WebApi.AspNetCore\Hl7.Fhir.R4.WebApi.AspNetCore.csproj" />

--- a/src/Hl7.DemoFileSystemFhirServer.AspNetCore/Startup.cs
+++ b/src/Hl7.DemoFileSystemFhirServer.AspNetCore/Startup.cs
@@ -123,6 +123,7 @@ namespace Hl7.DemoFileSystemFhirServer
                 options.OutputFormatters.Add(new Fhir.WebApi.SimpleHtmlFhirOutputFormatter());
             }, reverseProxyAddresses);
 
+            
             // register the Static Content
 #if NETCOREAPP2_2
             services.Configure<RazorViewEngineOptions>(options =>
@@ -131,6 +132,7 @@ namespace Hl7.DemoFileSystemFhirServer
                 options.FileProviders.Add(new PhysicalFileProvider(System.IO.Path.Combine(Directory.GetCurrentDirectory(), "wwwroot")));
             });
 #else
+            services.AddSwaggerGen();
             services.AddRazorPages(options =>
             {
                 options.RootDirectory = "/wwwroot";
@@ -162,6 +164,11 @@ namespace Hl7.DemoFileSystemFhirServer
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "WeatherApi v1");
+                });
             }
 
             app.UseResponseCompression();

--- a/src/Hl7.Fhir.WebApi.AspNetCore/FhirController.cs
+++ b/src/Hl7.Fhir.WebApi.AspNetCore/FhirController.cs
@@ -213,7 +213,7 @@ namespace Hl7.Fhir.WebApi
             return con;
         }
 
-        [HttpGet, Route(@"{ResourceName:regex(^((?!(C|c)ontent)(?!(S|S)cripts)[[A-Za-z]])+$)}/{id:regex(^(?!$.+)([[A-Za-z0-9\.-]])+$)}")]
+        [HttpGet, Route(@"{ResourceName:regex(^((?!(C|c)ontent)(?!(S|S)cripts)(?!(S|S)wagger)[[A-Za-z]])+$)}/{id:regex(^(?!$.+)([[A-Za-z0-9\.-]])+$)}")]
         public Task<IActionResult> Get(string ResourceName, string id)
         {
             return Get(ResourceName, id, null);
@@ -221,7 +221,7 @@ namespace Hl7.Fhir.WebApi
 
         // GET fhir/patient/5/_history/4
         //[HttpGet, Route("{type}/{id}/_history/{vid}")]
-        [HttpGet, Route(@"{ResourceName:regex(^((?!(C|c)ontent)(?!(S|S)cripts)[[A-Za-z]])+$)}/{id:regex(^(?!$.+)([[A-Za-z0-9\.-]])+$)}/_history/{vid}")]
+        [HttpGet, Route(@"{ResourceName:regex(^((?!(C|c)ontent)(?!(S|S)cripts)(?!(S|S)wagger)[[A-Za-z]])+$)}/{id:regex(^(?!$.+)([[A-Za-z0-9\.-]])+$)}/_history/{vid}")]
         public async Task<IActionResult> Get(string ResourceName, string id, string vid)
         {
             LogMessage("GET: " + this.Request.GetDisplayUrl());

--- a/src/Test.WebApi.AspNetCore/BasicTests.cs
+++ b/src/Test.WebApi.AspNetCore/BasicTests.cs
@@ -105,6 +105,24 @@ namespace UnitTestWebApi
         }
 
         [TestMethod]
+        public void GetSwaggerUI()
+        {
+            HttpClient c = new HttpClient();
+            var result = c.GetAsync(_baseAddress + "Swagger/index.html").Result;
+
+            System.Diagnostics.Trace.WriteLine(result.ToString());
+
+            Assert.AreEqual(HttpStatusCode.OK, result.StatusCode, "Should be status ok");
+            Assert.AreEqual("text/html", result.Content.Headers.ContentType.MediaType, "Should be status ok");
+
+            Assert.IsTrue(
+                result.Content
+                    .ReadAsStringAsync().GetAwaiter().GetResult()
+                    .Contains("./swagger-ui.css"),
+                "Does not seem to be the standard swagger ui html");
+        }
+
+        [TestMethod]
         public async Task GetCapabilityStatement()
         {
             LegacyFhirClient clientFhir = new LegacyFhirClient(_baseAddress, false);


### PR DESCRIPTION
As a consumer of HL7.Fhir.R4.WebApi.AspNetCore, I want to use Swagger in my Asp.Net Web app.
Adding Swagger to the Route regex as a negative match.
Test included.
Swashbuckle.AspNetCore added to Asp.Net Demo Server.
