### PR TITLE
Ignore Header parameters so that charset=utf-8 will not fail to match on a valid Formatter

### DIFF
--- a/src/Test.WebApi.AspNetCore/BasicTests.cs
+++ b/src/Test.WebApi.AspNetCore/BasicTests.cs
@@ -6,6 +6,7 @@ using Hl7.Fhir.Specification.Terminology;
 using Hl7.Fhir.Validation;
 using Hl7.Fhir.WebApi;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -14,6 +15,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Threading;
 using Task = System.Threading.Tasks.Task;
 
@@ -947,6 +949,79 @@ namespace UnitTestWebApi
             {
                 DebugDumpOutputXml(ex.Outcome);
                 throw;
+            }
+
+        }
+
+        [TestMethod]
+        public async Task RequestAcceptJsonWithHeaderParameter()
+        {
+            var app = new UnitTestFhirServerApplication();
+            var httpClient = app.CreateClient();
+            var acceptHeader = "application/json+fhir";
+            var acceptHeaderWithEncoding = "application/json+fhir; charset=utf-8";
+            var acceptHeaderWithEncodingAndVersion = "application/json+fhir; carset=utf-8; fhirVersion=4.0";
+            var badAcceptHeader = "application/notjson+fhir";
+            var acceptXmlHeader = "application/xml+fhir";
+
+            httpClient.DefaultRequestHeaders.Add("Accept", acceptHeader);
+            var raw = await httpClient.GetStringAsync($"{app.Server.BaseAddress}Patient");
+            
+            try
+            {
+                await new FhirJsonParser().ParseAsync<Bundle>(raw);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected Json formatted bundle: " + ex.Message);
+            }
+
+            httpClient.DefaultRequestHeaders.Remove("Accept");
+            httpClient.DefaultRequestHeaders.Add("Accept", acceptHeaderWithEncoding);
+            raw = await httpClient.GetStringAsync($"{app.Server.BaseAddress}Patient");
+            try
+            {
+                await new FhirJsonParser().ParseAsync<Bundle>(raw);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected Json formatted bundle: " + ex.Message);
+            }
+
+            httpClient.DefaultRequestHeaders.Remove("Accept");
+            httpClient.DefaultRequestHeaders.Add("Accept", acceptHeaderWithEncodingAndVersion);
+            raw = await httpClient.GetStringAsync($"{app.Server.BaseAddress}Patient");
+            try
+            {
+                await new FhirJsonParser().ParseAsync<Bundle>(raw);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected Json formatted bundle: " + ex.Message);
+            }
+
+            httpClient.DefaultRequestHeaders.Remove("Accept");
+            httpClient.DefaultRequestHeaders.Add("Accept", badAcceptHeader);
+            raw = await httpClient.GetStringAsync($"{app.Server.BaseAddress}Patient");
+            try
+            {
+                await new FhirXmlParser().ParseAsync<Bundle>(raw);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected Xml formatted bundle: " + ex.Message);
+            }
+
+            httpClient.DefaultRequestHeaders.Remove("Accept");
+            httpClient.DefaultRequestHeaders.Add("Accept", acceptXmlHeader);
+            raw = await httpClient.GetStringAsync($"{app.Server.BaseAddress}Patient");
+            try
+            {
+                await new FhirXmlParser().ParseAsync<Bundle>(raw);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected Xml formatted bundle: " + ex.Message);
             }
 
         }


### PR DESCRIPTION
The existing behavior can be seen by running the Hl7.DemoFileSystemFhirServer.AspNetCore project as is. Requesting a fhir resource with an "Accept" header of "application/json+fhir; charset=utf-8" I would expect the results to be json but they are returned as xml.  But, because the base type of TextInputFormatter matches on the header parameters also we do not find a matching formatter and return the first one registered. 

This PR overrides CanWriteResult to ignore the header parameter. This results in the Json Formatter being selected for output formatting. It may be appropriate to check encoding if it exists and ensure it is not something other than utf-8. Also this code would allow a path forward for other misc header parameters like fhirVersion.  

